### PR TITLE
chore(dependabot): add dependabot config file

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,39 @@
+---
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      minor:
+        patterns:
+        - "*"
+        update-types:
+        - "minor"
+        - "patch"
+  - package-ecosystem: "gomod"
+    directory: "."
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      minor:
+        patterns:
+        - "*"
+        update-types:
+        - "minor"
+        - "patch"
+  - package-ecosystem: "gomod"
+    directory: ".containifyci"
+    schedule:
+      interval: "daily"
+    groups:
+      minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Add dependabot configuration to automate dependency updates for GitHub Actions and Go modules.

- Add dependabot.yaml for automating updates
- Schedule weekly checks for github-actions and root gomod
- Schedule daily checks for .containifyci gomod