### PR TITLE
chore(deps): update Go version to 1.24.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containifyci/temporal-worker
 
-go 1.23.5
+go 1.24.2
 
 require (
 	github.com/containifyci/dunebot v0.0.3


### PR DESCRIPTION
Update the Go version in go.mod from 1.23.5 to 1.24.2 to use the latest features and fixes.

- Update Go version in go.mod