### PR TITLE
fix: upgrade go-github from v85 to v89 for palantir/go-githubapp v0.46.0 compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/containifyci/go-self-update v0.2.7
 	github.com/dusted-go/logging v1.3.0
 	github.com/golang/mock v1.6.0
-	github.com/google/go-github/v85 v85.0.0
+	github.com/google/go-github/v89 v89.0.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/palantir/go-githubapp v0.46.0
 	github.com/stretchr/testify v1.11.1
@@ -29,7 +29,6 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/go-github/v88 v88.0.0 // indirect
-	github.com/google/go-github/v89 v89.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 // indirect
@@ -62,3 +61,5 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/containifyci/dunebot => github.com/franky-agent/dunebot v0.3.14-fix1

--- a/go.mod
+++ b/go.mod
@@ -9,12 +9,12 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/go-github/v85 v85.0.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
-	github.com/palantir/go-githubapp v0.45.0
+	github.com/palantir/go-githubapp v0.46.0
 	github.com/stretchr/testify v1.11.1
-	go.temporal.io/api v1.63.1
-	go.temporal.io/sdk v1.45.0
+	go.temporal.io/api v1.63.3
+	go.temporal.io/sdk v1.46.0
 	go.uber.org/zap v1.28.0
-	golang.org/x/mod v0.37.0
+	golang.org/x/mod v0.38.0
 	golang.org/x/oauth2 v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -29,6 +29,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/go-github/v88 v88.0.0 // indirect
+	github.com/google/go-github/v89 v89.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/containifyci/temporal-worker
 go 1.26.0
 
 require (
-	github.com/containifyci/dunebot v0.3.13
+	github.com/containifyci/dunebot v0.3.14
 	github.com/containifyci/go-self-update v0.2.7
 	github.com/dusted-go/logging v1.3.0
 	github.com/golang/mock v1.6.0
@@ -61,5 +61,3 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-replace github.com/containifyci/dunebot => github.com/franky-agent/dunebot v0.3.14-fix1

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/bradleyfalzon/ghinstallation/v2 v2.19.0 h1:KQfD+43pRw9NUJhGycGrFr9vF1
 github.com/bradleyfalzon/ghinstallation/v2 v2.19.0/go.mod h1:fe5ECIhCdEnxwLiBlNTxx9CP455wt42BELnlDVMvaAA=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/containifyci/dunebot v0.3.13 h1:M+j79aawR1L7HOHw20lHc0j8ZjWi/4mAZAp6ZPbLZeA=
-github.com/containifyci/dunebot v0.3.13/go.mod h1:o6wj2UlZIED0TgPLBGCiE5DmzSqqvc4dK6IjH2slrI0=
 github.com/containifyci/go-self-update v0.2.7 h1:lBvhPP2UIRzs/jwfBnQCjzp6lyXPlvCM0vocvwp0CyY=
 github.com/containifyci/go-self-update v0.2.7/go.mod h1:lj4fxwO5INeEEV99Bv3v/XHRfdRCMzl0aeWVgks3mTk=
 github.com/containifyci/oauth2-storage v0.2.2 h1:s3qFn0Rs+56adIOTT362Xquuj2k+oixBMHk+T1uVzKA=
@@ -14,6 +12,8 @@ github.com/dusted-go/logging v1.3.0 h1:SL/EH1Rp27oJQIte+LjWvWACSnYDTqNx5gZULin0X
 github.com/dusted-go/logging v1.3.0/go.mod h1:s58+s64zE5fxSWWZfp+b8ZV0CHyKHjamITGyuY1wzGg=
 github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a h1:yDWHCSQ40h88yih2JAcL6Ls/kVkSE8GFACTGVnMPruw=
 github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a/go.mod h1:7Ga40egUymuWXxAe151lTNnCv97MddSOVsjpPPkityA=
+github.com/franky-agent/dunebot v0.3.14-fix1 h1:lFsPmtuLuE4k9S5Xyar1gNPDtW6DB7b6xdV32BlUq+U=
+github.com/franky-agent/dunebot v0.3.14-fix1/go.mod h1:amqgtSQo1hoaM8/dlgird0qbE1WB6YzyEhyq3xaaNo4=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -33,8 +33,6 @@ github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v85 v85.0.0 h1:1+TLFX/akTFXK7o9Z9uAloQGufOn4ySa5DItUM1VWT4=
-github.com/google/go-github/v85 v85.0.0/go.mod h1:jYkBnqN+SzR2A2fGKYfbt6DEEQAyxeK0Q2XpPV9ZFsU=
 github.com/google/go-github/v88 v88.0.0 h1:dZA9IKkPK1eXZj4ypngnpRj5FwdpTv4whix2PrQMP7M=
 github.com/google/go-github/v88 v88.0.0/go.mod h1:rufTDgn2N45wjhukLTyxmvc9nilSp3mr3Rgtt6b1MPw=
 github.com/google/go-github/v89 v89.0.0 h1:35bEK5XoEcF3PZrlVbl9XN63f5BcJRA/UGkxeC9xPg0=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/bradleyfalzon/ghinstallation/v2 v2.19.0 h1:KQfD+43pRw9NUJhGycGrFr9vF1
 github.com/bradleyfalzon/ghinstallation/v2 v2.19.0/go.mod h1:fe5ECIhCdEnxwLiBlNTxx9CP455wt42BELnlDVMvaAA=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/containifyci/dunebot v0.3.14 h1:f40mX9oyFalftVH8/i0cm5nzF/ycCc1eEfQ22ynpMi4=
+github.com/containifyci/dunebot v0.3.14/go.mod h1:amqgtSQo1hoaM8/dlgird0qbE1WB6YzyEhyq3xaaNo4=
 github.com/containifyci/go-self-update v0.2.7 h1:lBvhPP2UIRzs/jwfBnQCjzp6lyXPlvCM0vocvwp0CyY=
 github.com/containifyci/go-self-update v0.2.7/go.mod h1:lj4fxwO5INeEEV99Bv3v/XHRfdRCMzl0aeWVgks3mTk=
 github.com/containifyci/oauth2-storage v0.2.2 h1:s3qFn0Rs+56adIOTT362Xquuj2k+oixBMHk+T1uVzKA=
@@ -12,8 +14,6 @@ github.com/dusted-go/logging v1.3.0 h1:SL/EH1Rp27oJQIte+LjWvWACSnYDTqNx5gZULin0X
 github.com/dusted-go/logging v1.3.0/go.mod h1:s58+s64zE5fxSWWZfp+b8ZV0CHyKHjamITGyuY1wzGg=
 github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a h1:yDWHCSQ40h88yih2JAcL6Ls/kVkSE8GFACTGVnMPruw=
 github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a/go.mod h1:7Ga40egUymuWXxAe151lTNnCv97MddSOVsjpPPkityA=
-github.com/franky-agent/dunebot v0.3.14-fix1 h1:lFsPmtuLuE4k9S5Xyar1gNPDtW6DB7b6xdV32BlUq+U=
-github.com/franky-agent/dunebot v0.3.14-fix1/go.mod h1:amqgtSQo1hoaM8/dlgird0qbE1WB6YzyEhyq3xaaNo4=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/google/go-github/v85 v85.0.0 h1:1+TLFX/akTFXK7o9Z9uAloQGufOn4ySa5DItU
 github.com/google/go-github/v85 v85.0.0/go.mod h1:jYkBnqN+SzR2A2fGKYfbt6DEEQAyxeK0Q2XpPV9ZFsU=
 github.com/google/go-github/v88 v88.0.0 h1:dZA9IKkPK1eXZj4ypngnpRj5FwdpTv4whix2PrQMP7M=
 github.com/google/go-github/v88 v88.0.0/go.mod h1:rufTDgn2N45wjhukLTyxmvc9nilSp3mr3Rgtt6b1MPw=
+github.com/google/go-github/v89 v89.0.0 h1:35bEK5XoEcF3PZrlVbl9XN63f5BcJRA/UGkxeC9xPg0=
+github.com/google/go-github/v89 v89.0.0/go.mod h1:QLcbU0ipeAqQuR5KSg8c2lql4Qk1EwJ2dWz/0rP4Nho=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -65,8 +67,8 @@ github.com/nexus-rpc/nexus-proto-annotations v0.1.0 h1:2fELd+9sqUtNu6Fg//pw8YFsx
 github.com/nexus-rpc/nexus-proto-annotations v0.1.0/go.mod h1:n3UjF1bPCW8llR8tHvbxJ+27yPWrhpo8w/Yg1IOuY0Y=
 github.com/nexus-rpc/sdk-go v0.6.0 h1:QRgnP2zTbxEbiyWG/aXH8uSC5LV/Mg1fqb19jb4DBlo=
 github.com/nexus-rpc/sdk-go v0.6.0/go.mod h1:FHdPfVQwRuJFZFTF0Y2GOAxCrbIBNrcPna9slkGKPYk=
-github.com/palantir/go-githubapp v0.45.0 h1:wVldKEz7ZNjbqcwlUUOuQW6SDTB4kyN1WaIOuMB8yaY=
-github.com/palantir/go-githubapp v0.45.0/go.mod h1:OrIFZV9FEKYvW0UQX/lDt6TNtd1HmXmlzIL/6crBuIs=
+github.com/palantir/go-githubapp v0.46.0 h1:msMkNXfVjHRCCXEd3qtR07uAgFkxk+rJkjqCb1agytU=
+github.com/palantir/go-githubapp v0.46.0/go.mod h1:VXxkyizJTO4ham7U3O7kh4JU4cAG0yrE4Oe2Maa7f+w=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -104,10 +106,10 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
-go.temporal.io/api v1.63.1 h1:EwpJfApKq3fyu/uN+9VI6MAxfDFPAR6SjhXxyNSEvPE=
-go.temporal.io/api v1.63.1/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
-go.temporal.io/sdk v1.45.0 h1:kvsczo3SHTS60+zBWH9lljLmBLWSXcyGkBxr88z8iQI=
-go.temporal.io/sdk v1.45.0/go.mod h1:vkApR12F9/Y8OR+hkxe7WyXQFuCX6clhzqnAk6rzDAM=
+go.temporal.io/api v1.63.3 h1:09yoemfjnk1YHV6g402lMW1vZccUd9Au/NfQBEZC0Eo=
+go.temporal.io/api v1.63.3/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
+go.temporal.io/sdk v1.46.0 h1:zD2l907+4iVkLsnJZwFj/oIIjYsoqyjsHlKO/3tDKoU=
+go.temporal.io/sdk v1.46.0/go.mod h1:x3v/9ImVh469kiHspoq1xgLdPnetbfuCAm+Y1+sUtIo=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
@@ -124,8 +126,8 @@ golang.org/x/exp v0.0.0-20260611194520-c48552f49976/go.mod h1:vnf4pv9iKZXY58sQE1
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
-golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
+golang.org/x/mod v0.38.0 h1:MECBjubtXD7yj4HrhIUcywNaGeNVUdfVnxmPajOk4yk=
+golang.org/x/mod v0.38.0/go.mod h1:V6Xz0pq8TQ3dGqVQ1FVHuelZpAL0uNhSkk9ogYP3c40=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/pkg/activities/github/client.go
+++ b/pkg/activities/github/client.go
@@ -1,24 +1,24 @@
 package github
 
 import (
-	"context"
 	"net/http"
 
-	github "github.com/google/go-github/v85/github"
+	github "github.com/google/go-github/v89/github"
 	"golang.org/x/oauth2"
 )
 
 // NewGitHubClient creates an authenticated GitHub client using a personal access token
-func NewGitHubClient(ctx context.Context, token string) *github.Client {
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	)
-	tc := oauth2.NewClient(ctx, ts)
-	return github.NewClient(tc)
+func NewGitHubClient(token string) *github.Client {
+	client, err := github.NewClient(github.WithAuthToken(token))
+	if err != nil {
+		// WithAuthToken should never return an error, but handle it defensively
+		panic("unexpected error creating GitHub client: " + err.Error())
+	}
+	return client
 }
 
 // NewGitHubClientWithHTTP creates an authenticated GitHub client with a custom HTTP client
-func NewGitHubClientWithHTTP(ctx context.Context, token string, httpClient *http.Client) *github.Client {
+func NewGitHubClientWithHTTP(token string, httpClient *http.Client) *github.Client {
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
 	)
@@ -34,5 +34,9 @@ func NewGitHubClientWithHTTP(ctx context.Context, token string, httpClient *http
 		Timeout:       httpClient.Timeout,
 		Jar:           httpClient.Jar,
 	}
-	return github.NewClient(oauthClient)
+	client, err := github.NewClient(github.WithHTTPClient(oauthClient))
+	if err != nil {
+		panic("unexpected error creating GitHub client: " + err.Error())
+	}
+	return client
 }

--- a/pkg/activities/golang/dependabot.go
+++ b/pkg/activities/golang/dependabot.go
@@ -93,7 +93,7 @@ func FetchDependabotConfigFromGitHub(ctx context.Context, i FetchDependabotConfi
 	}
 
 	// Create GitHub client using the shared helper
-	client := githubactivity.NewGitHubClient(ctx, githubToken)
+	client := githubactivity.NewGitHubClient(githubToken)
 
 	// Try both .yaml and .yml extensions
 	filePaths := []string{".github/dependabot.yaml", ".github/dependabot.yml"}

--- a/pkg/activities/golang/pr.go
+++ b/pkg/activities/golang/pr.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	github "github.com/google/go-github/v85/github"
+	github "github.com/google/go-github/v89/github"
 	"go.temporal.io/sdk/activity"
 	"go.uber.org/zap"
 
@@ -34,7 +34,7 @@ func CountOpenMajorUpgradePRs(ctx context.Context, i CountOpenMajorUpgradePRsInp
 		return CountOpenMajorUpgradePRsOutputs{}, fmt.Errorf("GITHUB_TOKEN environment variable is required")
 	}
 
-	client := githubactivity.NewGitHubClient(ctx, githubToken)
+	client := githubactivity.NewGitHubClient(githubToken)
 
 	// List all open PRs
 	allPRs := make([]*github.PullRequest, 0)
@@ -99,7 +99,7 @@ func CheckPRExistsForBranch(ctx context.Context, i CheckPRExistsForBranchInputs)
 		return CheckPRExistsForBranchOutputs{}, fmt.Errorf("GITHUB_TOKEN environment variable is required")
 	}
 
-	client := githubactivity.NewGitHubClient(ctx, githubToken)
+	client := githubactivity.NewGitHubClient(githubToken)
 
 	// List open PRs and find one with matching head branch
 	opt := &github.PullRequestListOptions{
@@ -167,7 +167,7 @@ func PRCreate(ctx context.Context, i PRCreateInputs) (PRCreateOutputs, error) {
 		return PRCreateOutputs{}, fmt.Errorf("GITHUB_TOKEN environment variable is required")
 	}
 
-	client := githubactivity.NewGitHubClient(ctx, githubToken)
+	client := githubactivity.NewGitHubClient(githubToken)
 	sugar := zap.NewExample().Sugar()
 
 	// Get the default branch
@@ -227,7 +227,7 @@ func PRAddLabels(ctx context.Context, i PRAddLabelsInputs) error {
 		return fmt.Errorf("GITHUB_TOKEN environment variable is required")
 	}
 
-	client := githubactivity.NewGitHubClient(ctx, githubToken)
+	client := githubactivity.NewGitHubClient(githubToken)
 	sugar := zap.NewExample().Sugar()
 	accessor := NewAccessor(client, sugar)
 
@@ -256,7 +256,7 @@ func PRComment(ctx context.Context, i PRCommentInputs) (string, error) {
 		return "", fmt.Errorf("GITHUB_TOKEN environment variable is required")
 	}
 
-	client := githubactivity.NewGitHubClient(ctx, githubToken)
+	client := githubactivity.NewGitHubClient(githubToken)
 
 	_, _, err := client.Issues.CreateComment(ctx, i.Org, i.RepoName, i.ID, &github.IssueComment{
 		Body: &i.Message,


### PR DESCRIPTION
## Problem

PR #86 bumps `palantir/go-githubapp` from v0.45.0 to v0.46.0, which upgraded its `go-github` dependency from v88 to v89. This causes two issues:

1. **dunebot type mismatch**: `dunebot@v0.3.13` uses `go-github/v88` internally, but `palantir/go-githubapp v0.46.0` expects `go-github/v89`, causing compile errors:
   ```
   pkg/config/repoconfig.go:140:35: cannot use client (variable of type *github.Client) as *v89/github.Client
   ```

2. **temporal-worker own API changes**: `go-github/v89` has breaking API changes from v85:
   - `NewClient()` now returns `(*Client, error)` instead of `*Client`
   - `NewClient()` now takes `ClientOptionsFunc` instead of `*http.Client`
   - New `WithAuthToken()` and `WithHTTPClient()` options replace direct HTTP client passing

## Fix

- Updated all `go-github` imports from v85 to v89
- Updated `NewGitHubClient` and `NewGitHubClientWithHTTP` to use the new v89 API:
  - Simplified `NewGitHubClient` to use `WithAuthToken()`
  - Updated `NewGitHubClientWithHTTP` to use `WithHTTPClient()`
  - Removed `ctx` parameter from both helpers (no longer needed)
- Updated all callers to remove the `ctx` parameter
- Added a `replace` directive for `dunebot` pointing to a fork with the v89 fix

## Testing

- `go build ./...` passes ✅
- All existing tests pass (pre-existing `TestFetchDependabotConfigFromGitHub_NoToken` failure is unrelated)

## Dependencies

This PR depends on [containifyci/dunebot#134](https://github.com/containifyci/dunebot/pull/134) (go-github v89 upgrade) being merged first. The `replace` directive in `go.mod` can be removed once dunebot releases a v89-compatible version.